### PR TITLE
Dj 31 support

### DIFF
--- a/jsonstore/fields.py
+++ b/jsonstore/fields.py
@@ -25,6 +25,12 @@ def JSONField(*args, **kwargs):
         backend = import_module('{}.base'.format(settings.DATABASES['default']['ENGINE']).replace('_psycopg2', ''))
         db_vendor = backend.DatabaseWrapper.vendor
 
+    try:
+        from django.models import JSONField as DJ_JSONField
+        return DJ_JSONField(*args, **kwargs)
+    except ImportError:
+        pass
+        
     if db_vendor == 'postgresql':
         from django.contrib.postgres.fields import JSONField as PG_JSONField
         return PG_JSONField(*args, **kwargs)

--- a/jsonstore/fields.py
+++ b/jsonstore/fields.py
@@ -26,7 +26,7 @@ def JSONField(*args, **kwargs):
         db_vendor = backend.DatabaseWrapper.vendor
 
     try:
-        from django.models import JSONField as DJ_JSONField
+        from django.db.models import JSONField as DJ_JSONField
         return DJ_JSONField(*args, **kwargs)
     except ImportError:
         pass


### PR DESCRIPTION
JSONField is a first class citizen in Django 3.1, and so the field can be simplified if DJ 3.1 is in use.